### PR TITLE
add org property to role list if exists

### DIFF
--- a/docs/methods/role.list.md
+++ b/docs/methods/role.list.md
@@ -64,8 +64,12 @@ Authorization: `Bearer ${accessToken}`
     "isSystemRole": false,
     "usersCount": 5,
     "permissions": [
-      "5b969dc9901e2af192780a34",
+      "5b969dc9901e2af192780a34"
     ],
+    "org": {
+      "id": "8a9295c9901e7af196785a34",
+      "name": "acme"
+    },
     "createdAt": "2017-07-13T05:00:42.145Z",
     "updatedAt": "2017-07-13T05:42:42.222Z"
   }],

--- a/server/api/role/list/controller.test.js
+++ b/server/api/role/list/controller.test.js
@@ -112,7 +112,12 @@ describe('api/v1/role.list', () => {
       .send();
 
     expect(res.status).toBe(200);
-    expect(res.body.roles.length).toBe(3);
+    // NOTE: Even though the user is assigned 3 roles, one of them is global.
+    //       If the user has no access to the global org domain then they wont 
+    //       be able to read its roles. Imagine a user having only write priviledges
+    //       but not read. This would be weird but still valid. Changing the behaviour
+    //       of this would mean adding more complex checks that are currently not needed.
+    expect(res.body.roles.length).toBe(2);
     expect(res.body).toMatchObject({
       ok: true,
       roles: expect.arrayContaining([

--- a/server/api/role/list/controller.test.js
+++ b/server/api/role/list/controller.test.js
@@ -109,6 +109,10 @@ describe('api/v1/role.list', () => {
           permissions: expect.arrayContaining([expect.any(String)]),
           createdAt: expect.any(String),
           updatedAt: expect.any(String),
+          org: expect.objectContaining({
+            id: expect.any(String),
+            name: expect.any(String),
+          }),
         }),
       ]),
     });
@@ -135,6 +139,10 @@ describe('api/v1/role.list', () => {
           permissions: expect.arrayContaining([expect.any(String)]),
           createdAt: expect.any(String),
           updatedAt: expect.any(String),
+          org: expect.objectContaining({
+            id: expect.any(String),
+            name: expect.any(String),
+          }),
         }),
       ]),
       nextCursor: expect.any(String),

--- a/server/api/role/list/controller.test.js
+++ b/server/api/role/list/controller.test.js
@@ -112,11 +112,8 @@ describe('api/v1/role.list', () => {
       .send();
 
     expect(res.status).toBe(200);
-    // NOTE: Even though the user is assigned 3 roles, one of them is global.
-    //       If the user has no access to the global org domain then they wont 
-    //       be able to read its roles. Imagine a user having only write priviledges
-    //       but not read. This would be weird but still valid. Changing the behaviour
-    //       of this would mean adding more complex checks that are currently not needed.
+    // NOTE: global rules are not supposed to be sent back if a user
+    //       has no permissions to read them.
     expect(res.body.roles.length).toBe(2);
     expect(res.body).toMatchObject({
       ok: true,

--- a/server/api/role/list/service.js
+++ b/server/api/role/list/service.js
@@ -1,5 +1,5 @@
 import { ObjectId } from 'mongodb';
-import get from 'lodash/get';
+import has from 'lodash/has';
 import escapeRegExp from 'lodash/escapeRegExp';
 
 export const stringifyCursor = ({ id }) => {
@@ -72,7 +72,7 @@ async function listRoles(db, { q, limit, cursor, scopes }) {
     {
       $unwind: {
         path: '$org',
-          'preserveNullAndEmptyArrays': true,
+        preserveNullAndEmptyArrays: true,
       },
     },
     {
@@ -83,10 +83,10 @@ async function listRoles(db, { q, limit, cursor, scopes }) {
   return roles.map((role) => ({
     id: role._id.toHexString(),
     name: role.name,
-    org: {
-      id: get(role, 'org._id') && get(role, 'org._id').toHexString(),
-      name: get(role, 'org.name'),
-    },
+    org: has(role, ['org', '_id']) ? {
+      id: role.org._id.toHexString(),
+      name: role.org.name,
+    } : null,
     description: role.description,
     isSystemRole: role.isSystemRole,
     permissions: role.permissions,


### PR DESCRIPTION
fixes #38

@jmike I had a problem while testing the Roles list. I am expecting that Roles list API should also include global roles the user has access to. Is that not the case? Do global rules not include the `yeep.role.read` domain?

Apparently not. Should we? The test is currently failing and i also added some precautions on the query fetch for the case an org does not exist for a given role so that it doesn't crash in the future