### PR TITLE
Add extra filters to permissions.list endpoint

### DIFF
--- a/docs/methods/permission.list.md
+++ b/docs/methods/permission.list.md
@@ -19,7 +19,9 @@ Requestor must be authenticated. No explicit permissions are required; only retr
 - **q** _(string)_ — filters permissions by the designated query (optional)
 - **limit** _(string)_ — maximum number of permissions to return (optional)
 - **cursor** _(string)_ — paginates through permissions by setting the `cursor` param (optional)
-
+- **scope** _(string)_ — filters permissions by the designated org (optional)
+- **role** _(string)_ — retrieves all permissions under the designated role (optional)
+- **isSystemPermission** _(boolean)_ — retrieves only system permissions (optional)
 ***
 
 ## Returns

--- a/server/api/permission/list/controller.js
+++ b/server/api/permission/list/controller.js
@@ -55,10 +55,10 @@ const visitRequestedRole = async ({ request, db }, next) => {
 };
 
 const isUserAuthorised = async ({ request }, next) => {
-  // verify a user has access to the requested org
+  // verify user has access to the requested org
   if (request.body.scope) {
     const isScopeAccessible = findUserPermissionIndex(request.session.user.permissions, {
-      name: 'yeep.role.read',
+      name: 'yeep.permission.read',
       orgId: request.body.scope,
     }) !== -1;
 
@@ -66,7 +66,7 @@ const isUserAuthorised = async ({ request }, next) => {
       throw new AuthorizationError(
         `User "${
           request.session.user.username
-        }" does not have sufficient permissions to list permissions under org ${request.body.scope}`
+        }" is not authorized to list permissions under org ${request.body.scope}`
       );
     }
   }
@@ -75,7 +75,7 @@ const isUserAuthorised = async ({ request }, next) => {
     const hasPermission = Array.from(new Set([request.session.role.scope, null])).some(
       (orgId) =>
         findUserPermissionIndex(request.session.user.permissions, {
-          name: 'yeep.role.read',
+          name: 'yeep.permission.read',
           orgId,
         }) !== -1
     );
@@ -84,7 +84,7 @@ const isUserAuthorised = async ({ request }, next) => {
       throw new AuthorizationError(
         `User "${
           request.session.user.username
-        }" does not have sufficient permissions to access this resource`
+        }" is not authorized to list permissions under role ${request.session.role.id}`
       );
     }
   }

--- a/server/api/permission/list/controller.test.js
+++ b/server/api/permission/list/controller.test.js
@@ -19,6 +19,7 @@ describe('api/v1/permission.list', () => {
   let acme;
   let monsters;
   let role;
+  let unauthorisedRole;
   let permissions;
   let session;
 
@@ -54,24 +55,35 @@ describe('api/v1/permission.list', () => {
 
     // create test permission
     permissions = await Promise.all([
-      await createPermission(ctx.db, {
+      createPermission(ctx.db, {
         name: 'acme.code.write',
         description: 'Permission to edit (write, delete, update) source code',
         scope: acme.id,
       }),
-      await createPermission(ctx.db, {
+      createPermission(ctx.db, {
         name: 'monsters.code.write',
         description: 'Permission to edit (write, delete, update) source code',
         scope: monsters.id,
       }),
+      createPermission(ctx.db, {
+        name: 'global.code.write',
+        description: 'Permission to edit (write, delete, update) source code',
+      }),
     ]);
 
-    role = await createRole(ctx.db, {
-      name: 'monsters:developer',
-      description: 'Developer role',
-      permissions: [permissions[1].id],
-      scope: monsters.id,
-    });
+    [role, unauthorisedRole] = await Promise.all([
+      createRole(ctx.db, {
+        name: 'monsters:developer',
+        description: 'Developer role',
+        permissions: [permissions[1].id],
+        scope: monsters.id,
+      }),
+      createRole(ctx.db, {
+        name: 'global:developer',
+        description: 'Developer role',
+        permissions: [permissions[2].id],
+      }),
+    ])
 
     session = await createSession(ctx, {
       username: 'wile',
@@ -86,6 +98,7 @@ describe('api/v1/permission.list', () => {
     await deleteOrg(ctx.db, monsters);
     await deleteUser(ctx.db, wile);
     await deleteRole(ctx.db, role);
+    await deleteRole(ctx.db, unauthorisedRole);
     await server.teardown();
   });
 
@@ -257,6 +270,24 @@ describe('api/v1/permission.list', () => {
     });
     expect(res.body.permissions.length).toBe(1);
   });
+
+  test('throws an error when trying to filter by `role` param when unauthorised', async () => {
+    const res = await request(server)
+      .post('/api/v1/permission.list')
+      .set('Authorization', `Bearer ${session.accessToken}`)
+      .send({
+        role: unauthorisedRole.id,
+      });
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({
+      ok: false,
+      error: expect.objectContaining({
+        code: 10012,
+        message: expect.any(String),
+      }),
+    });
+  });
+
   test('filters permissions using `isSystemPermission` param', async () => {
     const res = await request(server)
       .post('/api/v1/permission.list')

--- a/server/api/permission/list/controller.test.js
+++ b/server/api/permission/list/controller.test.js
@@ -271,7 +271,7 @@ describe('api/v1/permission.list', () => {
     expect(res.body.permissions.length).toBe(1);
   });
 
-  test('throws an error when trying to filter by `role` param when unauthorised', async () => {
+  test('throws error when trying to filter by `role` param when unauthorised', async () => {
     const res = await request(server)
       .post('/api/v1/permission.list')
       .set('Authorization', `Bearer ${session.accessToken}`)

--- a/server/api/permission/list/service.js
+++ b/server/api/permission/list/service.js
@@ -17,7 +17,7 @@ async function listPermissions(db, { q, limit, cursor, scopes, role, isSystemPer
 
   if (!scopes.includes(null)) {
     matchExpressions.push({
-      scope: { $in: scopes.map((scope) => ObjectId(scope)) }
+      scope: { $in: scopes.map((scope) => ObjectId(scope)) },
     });
   }
 
@@ -26,19 +26,19 @@ async function listPermissions(db, { q, limit, cursor, scopes, role, isSystemPer
       name: {
         $regex: `^${escapeRegExp(q)}`,
         $options: 'i',
-      }
+      },
     });
   }
 
   if (cursor) {
     matchExpressions.push({
-      _id: { $gt: ObjectId(cursor.id) }
+      _id: { $gt: ObjectId(cursor.id) },
     });
   }
 
   if (role) {
     matchExpressions.push({
-      _id: { $in: role.permissions.map((permission) => ObjectId(permission)) }
+      _id: { $in: role.permissions.map((permission) => ObjectId(permission)) },
     });
   }
 
@@ -51,7 +51,7 @@ async function listPermissions(db, { q, limit, cursor, scopes, role, isSystemPer
   // retrieve permissions
   const permissions = await PermissionModel.aggregate([
     {
-      $match: { $and: matchExpressions }
+      $match: { $and: matchExpressions },
     },
     {
       $lookup: {
@@ -93,6 +93,11 @@ async function listPermissions(db, { q, limit, cursor, scopes, role, isSystemPer
           },
         ],
         as: 'roles',
+      },
+    },
+    {
+      $sort: {
+        _id: 1,
       },
     },
     {

--- a/server/api/permission/list/service.js
+++ b/server/api/permission/list/service.js
@@ -10,7 +10,7 @@ export const parseCursor = (cursorStr) => {
   return { id };
 };
 
-async function listPermissions(db, { q, limit, cursor, scopes, isSystemPermission }) {
+async function listPermissions(db, { q, limit, cursor, scopes, role, isSystemPermission }) {
   const PermissionModel = db.model('Permission');
 
   // retrieve permissions
@@ -36,6 +36,11 @@ async function listPermissions(db, { q, limit, cursor, scopes, isSystemPermissio
                 $gt: ObjectId(cursor.id),
               },
             }
+          : {},
+        role
+          ? {
+            _id: { $in: role.permissions.map((permission) => ObjectId(permission)) },
+          }
           : {},
         isSystemPermission
           ? {

--- a/server/api/permission/list/service.js
+++ b/server/api/permission/list/service.js
@@ -13,41 +13,45 @@ export const parseCursor = (cursorStr) => {
 async function listPermissions(db, { q, limit, cursor, scopes, role, isSystemPermission }) {
   const PermissionModel = db.model('Permission');
 
+  const matchExpressions = [];
+
+  if (!scopes.includes(null)) {
+    matchExpressions.push({
+      scope: { $in: scopes.map((scope) => ObjectId(scope)) }
+    });
+  }
+
+  if (q) {
+    matchExpressions.push({
+      name: {
+        $regex: `^${escapeRegExp(q)}`,
+        $options: 'i',
+      }
+    });
+  }
+
+  if (cursor) {
+    matchExpressions.push({
+      _id: { $gt: ObjectId(cursor.id) }
+    });
+  }
+
+  if (role) {
+    matchExpressions.push({
+      _id: { $in: role.permissions.map((permission) => ObjectId(permission)) }
+    });
+  }
+
+  if (isSystemPermission) {
+    matchExpressions.push({
+      isSystemPermission: { $eq: isSystemPermission },
+    });
+  }
+
   // retrieve permissions
   const permissions = await PermissionModel.aggregate([
     {
-      $match: Object.assign(
-        scopes.includes(null)
-          ? {}
-          : {
-              scope: { $in: scopes.map((scope) => ObjectId(scope)) },
-            },
-        q
-          ? {
-              name: {
-                $regex: `^${escapeRegExp(q)}`,
-                $options: 'i',
-              },
-            }
-          : {},
-        cursor
-          ? {
-              _id: {
-                $gt: ObjectId(cursor.id),
-              },
-            }
-          : {},
-        role
-          ? {
-            _id: { $in: role.permissions.map((permission) => ObjectId(permission)) },
-          }
-          : {},
-        isSystemPermission
-          ? {
-              isSystemPermission: { $eq: isSystemPermission },
-            }
-          : {},
-      ),
+      $match: { $and: matchExpressions }
     },
     {
       $lookup: {

--- a/server/api/permission/list/service.js
+++ b/server/api/permission/list/service.js
@@ -10,7 +10,7 @@ export const parseCursor = (cursorStr) => {
   return { id };
 };
 
-async function listPermissions(db, { q, limit, cursor, scopes }) {
+async function listPermissions(db, { q, limit, cursor, scopes, isSystemPermission }) {
   const PermissionModel = db.model('Permission');
 
   // retrieve permissions
@@ -36,7 +36,12 @@ async function listPermissions(db, { q, limit, cursor, scopes }) {
                 $gt: ObjectId(cursor.id),
               },
             }
-          : {}
+          : {},
+        isSystemPermission
+          ? {
+              isSystemPermission: { $eq: isSystemPermission },
+            }
+          : {},
       ),
     },
     {


### PR DESCRIPTION
fixes #45 .

- Added filtering by scope
- Added filtering by isSystemPermissions flag
- Added filtering by provided Role

In the case of requesting all permissions under a specific role:
* the role is fetched first
* then role reading permissions are checked
* it is validated against the logged in user
* and _then_ is the permissions aggregation query run with the provided ids from the role

This was done to exit early if the role does not exist or user has no permissions to read it.