### PR TITLE
Update babelrc target setting for admin ui

### DIFF
--- a/admin_ui/.babelrc.js
+++ b/admin_ui/.babelrc.js
@@ -10,7 +10,7 @@ module.exports = {
       '@babel/preset-env',
       {
         targets: {
-          browsers: ['last 2 versions', 'ie >= 11'],
+          browsers: ['since 2015', 'IE 11'],
         },
         debug: false,
       },


### PR DESCRIPTION
...to include browsers since 2015 + IE 11

Please note the previous setting was targeting IE10 due to the "last 2 versions" option.