### PR TITLE
Instruct jest to ignore the `dist` folder

### DIFF
--- a/config/jest.json
+++ b/config/jest.json
@@ -1,16 +1,12 @@
 {
   "rootDir": "..",
   "testEnvironment": "node",
-  "collectCoverageFrom": [
-    "server/**/*.{js}"
-  ],
-  "testPathIgnorePatterns": [
-    "/node_modules",
-    "/dist"
-  ],
+  "collectCoverageFrom": ["server/**/*.{js}"],
+  "testPathIgnorePatterns": ["/node_modules", "/dist"],
   "transform": {
     "^.+\\.jsx$": "babel-jest",
     "^.+\\.js$": "babel-jest"
   },
+  "modulePathIgnorePatterns": ["<rootDir>/dist"],
   "verbose": true
 }


### PR DESCRIPTION
and thus avoid the stupid "multiple package.json files detected" warning