### PR TITLE
add org.update endpoint

### DIFF
--- a/docs/methods/org.update.md
+++ b/docs/methods/org.update.md
@@ -1,0 +1,69 @@
+# org.update
+
+`POST /api/v1/org.update`
+
+## Description
+
+Updates the designated org with the specified properties.
+
+---
+
+## Auth logic
+
+Requestor must be authenticated and assigned with the `yeep.org.write` permission for the designated org scope or the _global_ scope.
+
+## Parameters
+
+### Body
+
+- **id** _(string)_ — org ID (required)
+- **name** _(string)_ — the name of the organization (required)
+- **slug** _(string)_ — the URL key of the organization, a.k.a. slug (required)
+
+_Please note: one of `name` or `slug` must be specified, otherwise update makes no sense._
+
+---
+
+## Returns
+
+**200 OK** alongside `Object` with the following properties:
+
+- **ok** _(boolean)_ — indicates whether the request was successfully completed
+- **error** _(Object)_ — contains error details in case of an error
+- **role** _(Object)_ — role details
+
+---
+
+## Example
+
+**Request**
+
+```
+POST /api/v1/org.update
+Authorization: `Bearer ${accessToken}`
+```
+
+```json
+{
+  "id": "507f1f77bcf86cd799439011",
+  "name": "Acme Inc",
+  "slug": "acme"
+}
+```
+
+**Response**
+
+`200 OK`
+
+```json
+{
+  "ok": true,
+  "org": {
+    "id": "507f1f77bcf86cd799439011",
+    "name": "Acme Inc",
+    "slug": "acme",
+    "createdAt": "2017-07-13T05:00:42.145Z",
+    "updatedAt": "2017-07-13T05:42:42.222Z"
+  }
+}
+```

--- a/docs/methods/org.update.md
+++ b/docs/methods/org.update.md
@@ -17,8 +17,8 @@ Requestor must be authenticated and assigned with the `yeep.org.write` permissio
 ### Body
 
 - **id** _(string)_ — org ID (required)
-- **name** _(string)_ — the name of the organization (required)
-- **slug** _(string)_ — the URL key of the organization, a.k.a. slug (required)
+- **name** _(string)_ — the name of the organization (optional)
+- **slug** _(string)_ — the URL key of the organization, a.k.a. slug (optional)
 
 _Please note: one of `name` or `slug` must be specified, otherwise update makes no sense._
 
@@ -30,7 +30,7 @@ _Please note: one of `name` or `slug` must be specified, otherwise update makes 
 
 - **ok** _(boolean)_ — indicates whether the request was successfully completed
 - **error** _(Object)_ — contains error details in case of an error
-- **role** _(Object)_ — role details
+- **org** _(Object)_ — org details
 
 ---
 

--- a/server/api/org/index.js
+++ b/server/api/org/index.js
@@ -1,6 +1,7 @@
 import Router from 'koa-router';
 import createOrg from './create';
 import deleteOrg from './delete';
+import updateOrg from './update';
 import listOrgs from './list';
 import addMember from './addMember';
 import removeMember from './removeMember';
@@ -12,6 +13,7 @@ const router = Router();
 router.post('org.create', '/org.create', createOrg);
 router.post('org.delete', '/org.delete', deleteOrg);
 router.post('org.list', '/org.list', listOrgs);
+router.post('org.update', '/org.update', updateOrg);
 router.post('org.addMember', '/org.addMember', addMember);
 router.post('org.removeMember', '/org.removeMember', removeMember);
 

--- a/server/api/org/update/controller.js
+++ b/server/api/org/update/controller.js
@@ -45,10 +45,13 @@ const doesRequestedOrgExist = async (ctx, next) => {
 };
 
 const isUserAuthorized = async ({ request }, next) => {
-  const hasPermission = findUserPermissionIndex(request.session.user.permissions, {
-    name: 'yeep.org.write',
-    orgId: request.body.id,
-  }) !== -1;
+  const hasPermission = Array.from(new Set([request.body.id, null])).some(
+    (orgId) =>
+      findUserPermissionIndex(request.session.user.permissions, {
+        name: 'yeep.role.write',
+        orgId,
+      }) !== -1
+  );
 
   if (!hasPermission) {
     throw new AuthorizationError(

--- a/server/api/org/update/controller.js
+++ b/server/api/org/update/controller.js
@@ -1,0 +1,98 @@
+import Joi from 'joi';
+import Boom from 'boom';
+import compose from 'koa-compose';
+import packJSONRPC from '../../../middleware/packJSONRPC';
+import { validateRequest } from '../../../middleware/validation';
+import {
+  decorateSession,
+  isUserAuthenticated,
+  decorateUserPermissions,
+  findUserPermissionIndex,
+} from '../../../middleware/auth';
+import updateOrg, { checkOrgExists } from './service';
+import { AuthorizationError, OrgNotFoundError } from '../../../constants/errors';
+
+export const validationSchema = {
+  body: {
+    id: Joi.string()
+      .length(24)
+      .hex()
+      .required(),
+    name: Joi.string()
+      .trim()
+      .min(3)
+      .max(100)
+      .optional(),
+    slug: Joi.string()
+      .lowercase()
+      .trim()
+      .min(3)
+      .max(30)
+      .optional()
+      .regex(/^[A-Za-z0-9\-_]*$/, { name: 'slug' }),
+  },
+};
+
+const doesRequestedOrgExist = async (ctx, next) => {
+  const { request } = ctx;
+  const org = await checkOrgExists(ctx, request.body.id);
+
+  if (!org) {
+    throw new OrgNotFoundError(`Org ${request.body.id} cannot be found`);
+  }
+
+  await next();
+};
+
+const isUserAuthorized = async ({ request }, next) => {
+  const hasPermission = findUserPermissionIndex(request.session.user.permissions, {
+    name: 'yeep.org.write',
+    orgId: request.body.id,
+  }) !== -1;
+
+  if (!hasPermission) {
+    throw new AuthorizationError(
+      `User ${request.session.user.id} does not have sufficient permissions to access this resource`
+    );
+  }
+
+  await next();
+};
+
+async function handler(ctx) {
+  const { request, response } = ctx;
+  const { id: orgId, name, slug } = request.body;
+
+  // ensure name or slug have been specified
+  if (!(name || slug)) {
+    const boom = Boom.badRequest('Invalid request body');
+    boom.output.payload.details = [
+      {
+        path: ['name'],
+        type: 'any.required',
+      },
+    ];
+    throw boom;
+  }
+
+  const org = await updateOrg(ctx, orgId, {
+    name,
+    slug,
+  });
+
+  response.status = 200; // OK
+  response.body = {
+    org,
+  };
+}
+
+export default compose([
+  packJSONRPC,
+  decorateSession(),
+  isUserAuthenticated(),
+  validateRequest(validationSchema),
+  decorateUserPermissions(),
+  doesRequestedOrgExist,
+  isUserAuthorized,
+  handler,
+]);

--- a/server/api/org/update/controller.test.js
+++ b/server/api/org/update/controller.test.js
@@ -1,0 +1,157 @@
+/* eslint-env jest */
+import request from 'supertest';
+import compareDesc from 'date-fns/compare_desc';
+import server from '../../../server';
+import config from '../../../../yeep.config';
+import createPermission from '../../permission/create/service';
+import createOrg from '../create/service';
+import createUser from '../../user/create/service';
+// import createPermissionAssignment from '../../user/assignPermission/service';
+import createSession from '../../session/create/service';
+import destroySession from '../../session/destroy/service';
+// import deletePermissionAssignment from '../../user/revokePermission/service';
+import deleteOrg from '../delete/service';
+import deleteUser from '../../user/delete/service';
+
+describe('api/org.update', () => {
+  let ctx;
+  let user;
+  let org;
+  let unauthorisedOrg;
+  let umbrella;
+  let session;
+
+  beforeAll(async () => {
+    await server.setup(config);
+    ctx = server.getAppContext();
+
+    user = await createUser(ctx, {
+      username: 'wile',
+      password: 'catch-the-b1rd$',
+      fullName: 'Wile E. Coyote',
+      picture: 'https://www.acme.com/pictures/coyote.png',
+      emails: [
+        {
+          address: 'coyote@acme.com',
+          isVerified: true,
+          isPrimary: true,
+        },
+      ],
+    });
+
+    [ org, unauthorisedOrg, umbrella ] = await Promise.all([
+      createOrg(ctx, {
+        name: 'Acme Inc',
+        slug: 'acme',
+        adminId: user.id,
+      }),
+      createOrg(ctx, {
+        name: 'DANGER_ZONE',
+        slug: 'donotenter',
+      }),
+      createOrg(ctx, {
+        name: 'Umbrella Corp',
+        slug: 'umbrella',
+        adminId: user.id,
+      }),
+    ]);
+
+    session = await createSession(ctx, {
+      username: 'wile',
+      password: 'catch-the-b1rd$',
+    });
+  });
+
+  afterAll(async () => {
+    await destroySession(ctx, session);
+    await deleteOrg(ctx, org);
+    await deleteOrg(ctx, unauthorisedOrg);
+    await deleteOrg(ctx, umbrella);
+    await deleteUser(ctx, user);
+    await server.teardown();
+  });
+
+  test('returns error when org does not exist', async () => {
+    const res = await request(server)
+      .post('/api/org.update')
+      .set('Authorization', `Bearer ${session.accessToken}`)
+      .send({
+        id: '5b2d5dd0cd86b77258e16d39', // some random objectid
+        name: 'Acme Tost',
+      });
+
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({
+      ok: false,
+      error: {
+        code: 10011,
+        message: 'Org 5b2d5dd0cd86b77258e16d39 cannot be found',
+      },
+    });
+  });
+
+  test('returns error when requestor has no write permissions on requested org', async () => {
+
+    const res = await request(server)
+      .post('/api/org.update')
+      .set('Authorization', `Bearer ${session.accessToken}`)
+      .send({
+        id: unauthorisedOrg.id,
+        name: 'Acme Tost',
+      });
+
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({
+      ok: false,
+      error: {
+        code: 10012,
+        message: `User ${user.id} does not have sufficient permissions to access this resource`,
+      },
+    });
+  });
+
+  test('returns error when neither slug nor name are present on the request', async () => {
+    const res = await request(server)
+      .post('/api/org.update')
+      .set('Authorization', `Bearer ${session.accessToken}`)
+      .send({
+        id: org.id, // some random objectid
+      });
+
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({
+      ok: false,
+      error: {
+        code: 400,
+        details: [{
+          path: ['name'], 
+          type: 'any.required',
+        }],
+        message: 'Invalid request body',
+      },
+    });
+  });
+
+  test('updates org and returns expected response', async () => {
+    const res = await request(server)
+      .post('/api/org.update')
+      .set('Authorization', `Bearer ${session.accessToken}`)
+      .send({
+        id: umbrella.id,
+        name: 'Umbrella Tost',
+        slug: 'umbrulla',
+      });
+
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({
+      ok: true,
+      org: {
+        id: umbrella.id,
+        name: 'Umbrella Tost',
+        slug: 'umbrulla',
+      },
+    });
+    expect(compareDesc(org.createdAt, res.body.org.createdAt)).toBe(0);
+    expect(compareDesc(org.updatedAt, res.body.org.updatedAt)).toBe(1);
+  });
+});

--- a/server/api/org/update/index.js
+++ b/server/api/org/update/index.js
@@ -1,0 +1,1 @@
+export { default } from './controller';

--- a/server/api/org/update/service.js
+++ b/server/api/org/update/service.js
@@ -1,0 +1,49 @@
+import { ObjectId } from 'mongodb';
+import {
+  DuplicateOrgError,
+  OrgNotFoundError,
+} from '../../../constants/errors';
+
+async function updateOrg({ db }, orgId, nextProps) {
+  const OrgModel = db.model('Org');
+
+  // update org in db
+  try {
+    const updatedAt = new Date();
+    await OrgModel.updateOne(
+      {
+        _id: ObjectId(orgId),
+      },
+      {
+        $set: {
+          ...nextProps,
+          updatedAt,
+        },
+      }
+    );
+
+    return {
+      id: orgId,
+      ...nextProps,
+      updatedAt,
+    };
+  } catch (err) {
+    if (err.code === 11000) {
+      throw new DuplicateOrgError(`Org "${orgId}" already exists`);
+    }
+
+    throw err;
+  }
+}
+
+export async function checkOrgExists({ db }, orgId) {
+  const OrgModel = db.model('Org');
+
+  const org = await OrgModel.findOne({
+    _id: ObjectId(orgId),
+  });
+
+  return org;
+}
+
+export default updateOrg;


### PR DESCRIPTION
Fixes #73 

### `checkOrgExists`
Since no `org.getInfo` endpoint existed, instead of creatin it i added an extra service `checkOrgExists` as a named export. It might be likely that we need a `getOrgInfo` in the future, but creating it just to use the service in this case seemed kind of an overkill.

I also thought about using the `isUserAuthorised` function to bail early if the user has no `yeep.org.write` permissions for the provided org id and _then_ check the existance of the given org inside the service, but this wasn't so clean and it would be harder to test.

Please advise if you would prefer a different method.

### `OrgMemberships`

Since the orgMemberships model only uses id references i didn't make any changes there.

Edit: Bear in mind that i didn't remove the '/v1/' from the docs for this endpoint. We need to make a good passthrough to all of them and i didn't want this file to miss out 🗡 

Edit2: I added the extra `unauthorisedOrg` inside the `beforeAll` loop. This would be better off inside the only test that is using it, but if the test fails before the org is deleted, then the database needs reset. It is ugly but it was worse if i left it inside the unit test.