### PR TITLE
add org param to user.list, update tests

### DIFF
--- a/docs/methods/user.list.md
+++ b/docs/methods/user.list.md
@@ -17,6 +17,7 @@ Requestor must be authenticated. No explicit permissions required; retrieves use
 ### Body
 
 - **q** _(string)_ — filters users by the designated query (optional)
+- **org** _(string)_ — filters users by the designated org (optional)
 - **limit** _(string)_ — maximum number of users to return (optional)
 - **cursor** _(string)_ — paginates through users by setting the `cursor` param (optional)
 - **projection** _(Object)_ — user fields to return (optional)

--- a/server/api/user/list/service.js
+++ b/server/api/user/list/service.js
@@ -24,7 +24,6 @@ export const defaultProjection = {
 
 async function listUsers({ db }, { q, limit, cursor, scopes, projection = defaultProjection }) {
   const UserModel = db.model('User');
-
   const users = await UserModel.aggregate([
     {
       $match: q


### PR DESCRIPTION
Notes
- I went with the name `org` for the param as the ticket dictated so (instead of scope).
- In a previous feature/addon (org.list) we said that in order for a user to make requests to the orgMembership model ( which this service does ) the user also needs to have the `yeep.permission||role.assignment.read` permissions. In the `role.list` and `permission.list` endpoints this is not the case. Should we enable it for those as well or remove it from the ones it already exists under?

fixes #44 