### PR TITLE
Fine-tune index collation

### DIFF
--- a/migrations/002-org.js
+++ b/migrations/002-org.js
@@ -4,7 +4,7 @@ export const up = async (db) => {
     {
       unique: true,
       name: 'slug_uidx',
-      collation: { locale: 'en', strength: 2 },
+      collation: { locale: 'en', strength: 1 },
     }
   );
 };

--- a/migrations/007-user.js
+++ b/migrations/007-user.js
@@ -4,7 +4,7 @@ export const up = async (db) => {
     {
       unique: true,
       name: 'email_address_uidx',
-      collation: { locale: 'en', strength: 2 },
+      collation: { locale: 'en', strength: 1 },
     }
   );
 };

--- a/migrations/008-user.js
+++ b/migrations/008-user.js
@@ -5,7 +5,7 @@ export const up = async (db) => {
       unique: true,
       sparse: true,
       name: 'username_uidx',
-      collation: { locale: 'en', strength: 2 },
+      collation: { locale: 'en', strength: 1 },
     }
   );
 };

--- a/migrations/011-permission.js
+++ b/migrations/011-permission.js
@@ -4,7 +4,7 @@ export const up = async (db) => {
     {
       unique: true,
       name: 'name_uidx',
-      collation: { locale: 'en', strength: 2 },
+      collation: { locale: 'en', strength: 1 },
     }
   );
 };

--- a/migrations/013-role.js
+++ b/migrations/013-role.js
@@ -4,7 +4,7 @@ export const up = async (db) => {
     {
       unique: true,
       name: 'name_uidx',
-      collation: { locale: 'en', strength: 2 },
+      collation: { locale: 'en', strength: 1 },
     }
   );
 };

--- a/server/models/Org.js
+++ b/server/models/Org.js
@@ -37,7 +37,7 @@ orgSchema.index(
   {
     unique: true,
     name: 'slug_uidx',
-    collation: { locale: 'en', strength: 2 },
+    collation: { locale: 'en', strength: 1 },
   }
 );
 

--- a/server/models/Permission.js
+++ b/server/models/Permission.js
@@ -41,7 +41,7 @@ permissionSchema.index(
   {
     unique: true,
     name: 'name_uidx',
-    collation: { locale: 'en', strength: 2 },
+    collation: { locale: 'en', strength: 1 },
   }
 );
 

--- a/server/models/Role.js
+++ b/server/models/Role.js
@@ -45,7 +45,7 @@ roleSchema.index(
   {
     unique: true,
     name: 'name_uidx',
-    collation: { locale: 'en', strength: 2 },
+    collation: { locale: 'en', strength: 1 },
   }
 );
 

--- a/server/models/User.js
+++ b/server/models/User.js
@@ -73,7 +73,7 @@ userSchema.index(
     unique: true,
     sparse: true,
     name: 'username_uidx',
-    collation: { locale: 'en', strength: 2 },
+    collation: { locale: 'en', strength: 1 },
   }
 );
 
@@ -82,7 +82,7 @@ userSchema.index(
   {
     unique: true,
     name: 'email_address_uidx',
-    collation: { locale: 'en', strength: 2 },
+    collation: { locale: 'en', strength: 1 },
   }
 );
 

--- a/server/models/User.js
+++ b/server/models/User.js
@@ -92,7 +92,7 @@ userSchema.index(
  * @return {string} normalized username
  */
 userSchema.statics.normalizeUsername = function(username) {
-  return username.normalize('NFKC').toLowerCase();
+  return username.toLowerCase();
 };
 
 /**


### PR DESCRIPTION
I've updated indices to use the `en` collation with a strength setting of `1`.

This essentially means that you may only have 1 of the following documents in the user collection...

```
- { username: 'foo' }
- { username: 'Foo' }
- { username: 'fóo' }
```

The index is build, ignoring accents (i.e. diacritics) and case-sensitivity. 
See https://docs.mongodb.com/manual/core/index-case-insensitive/#case-insensitive-indexes-on-collections-with-a-default-collation for further info.

You are still able to insert a record with an all-caps username - mongo will not prevent this (although the index will convert capitals to lowercase). It is thus extremely important that we normalize usernames, emails, slugs, etc to avoid the explicit use of the collation in query time and thus simplify operations.

tl;dr @spideynr please make sure you use `UserModel.normalize()` when loading the fixtures.