### PR TITLE
Angelos/43: Forgot password workflow

### DIFF
--- a/admin_ui/app/session/ForgotPasswordPage.js
+++ b/admin_ui/app/session/ForgotPasswordPage.js
@@ -1,24 +1,82 @@
-import React from 'react';
+import React, { useCallback, useState } from 'react';
 import { Link } from '@reach/router';
 import useDocumentTitle from '@rehooks/document-title';
+import { useSelector, useDispatch } from 'react-redux';
 import Input from '../../components/Input';
 import Button from '../../components/Button';
+import isEmpty from 'lodash/isEmpty';
+import { forgotPassword, resetForgotPasswordErrors } from './sessionStore';
 
 const ForgotPasswordPage = () => {
+  const isForgotPasswordPending = useSelector((state) => state.session.isForgotPasswordPending);
+  const isForgotPasswordComplete = useSelector((state) => state.session.isForgotPasswordComplete);
+  const forgotPasswordErrors = useSelector((state) => state.session.forgotPasswordErrors);
+  const dispatch = useDispatch();
+  const [userKey, setUserKey] = useState('');
+
+  const handleUserKeyChange = useCallback(
+    (event) => {
+      if (!isEmpty(forgotPasswordErrors)) {
+        dispatch(resetForgotPasswordErrors());
+      }
+      setUserKey(event.target.value);
+    },
+    [dispatch, forgotPasswordErrors]
+  );
+
+  const handleSubmit = useCallback(
+    (event) => {
+      event.preventDefault();
+      // Ensure only a single forgotPass request is
+      // running at any given time
+      if (!isForgotPasswordPending) {
+        dispatch(forgotPassword(userKey)).then(() => {
+        });
+      }
+    },
+    [dispatch, userKey, isForgotPasswordPending]
+  );
+
   useDocumentTitle('Forgot password - Yeep admin UI');
   return (
     <div className="w-screen min-h-screen bg-grey-light flex items-center justify-center">
-      <form className="block text-center w-full p-3 sm:w-auto" action="/">
+      <form className="block text-center w-full p-3 sm:w-auto" action="/" onSubmit={handleSubmit}>
         <img src="/yeep-logo-horizontal.svg" alt="Yeep logo" className="mb-6 w-48" />
         <h2 className="font-bold text-2xl mb-6">Yeep administration - Forgot password</h2>
+        {isForgotPasswordComplete && (
+          <div className="bg-green-lightest text-green-dark rounded border border-green p-3 mb-4">
+            TODO: Instructions go here
+          </div>
+        )}
         <div className="text-left mb-6">
           <label htmlFor="email" className="block mb-2">
             Username / email:
           </label>
-          <Input id="email" className="mb-4 w-full" placeholder="username or email" />
+          <Input
+            id="email"
+            className="mb-4 w-full"
+            placeholder="username or email"
+            value={userKey}
+            onChange={handleUserKeyChange}
+          />
         </div>
-        <Button className="w-4/5 mb-4">Sign in</Button>
-        <Link to="/login" className="block">Return to the login page</Link>
+        <Button type="submit" className="w-4/5 mb-4">
+          <React.Fragment>
+            {isForgotPasswordPending && (
+              <img
+                src="/spinner.svg"
+                alt="*"
+                width={20}
+                height={20}
+                className="inline-block mr-3 align-middle"
+              />
+            )}
+          </React.Fragment>
+          Submit form
+        </Button>
+        <Link to="/login" className="block">
+          Return to the login page
+        </Link>
       </form>
     </div>
   );

--- a/admin_ui/app/session/LoginPage.js
+++ b/admin_ui/app/session/LoginPage.js
@@ -9,14 +9,6 @@ import Button from '../../components/Button';
 import { login, resetLoginErrors } from './sessionStore';
 import classnames from 'classnames';
 
-function isUserKeyValid(userKey) {
-  return userKey.length >= 2;
-}
-
-function isPasswordValid(password) {
-  return password.length >= 8;
-}
-
 const LoginPage = () => {
   const isLoginPending = useSelector((state) => state.session.isLoginPending);
   const loginErrors = useSelector((state) => state.session.loginErrors);

--- a/admin_ui/app/session/sessionStore.js
+++ b/admin_ui/app/session/sessionStore.js
@@ -7,6 +7,9 @@ export const initialState = {
   user: {},
   loginErrors: {},
   isLoginPending: false,
+  forgotPasswordErrors: {},
+  isForgotPasswordPending: false,
+  isForgotPasswordComplete: false,
 };
 
 // actions
@@ -18,6 +21,10 @@ const rejectLogin = createAction('LOGIN_REJECT');
 export const resetLoginErrors = createAction('LOGIN_RESET_ERRORS');
 const initLogout = createAction('LOGOUT_INIT');
 export const resolveLogout = createAction('LOGOUT_RESOLVE');
+const initForgotPassword = createAction('FORGOT_PASSWORD_INIT');
+const resolveForgotPassword = createAction('FORGOT_PASSWORD_RESOLVE');
+const rejectForgotPassword = createAction('FORGOT_PASSWORD_REJECT');
+export const resetForgotPasswordErrors = createAction('FORGOT_PASSWORD_RESET_ERRORS');
 
 export const login = (user, password) => (dispatch) => {
   dispatch(initLogin());
@@ -51,9 +58,28 @@ export const logout = () => (dispatch) => {
     });
 };
 
+export const forgotPassword = () => (dispatch) => {
+  dispatch(initForgotPassword());
+  // TODO: Do we need to enhance YeepClient for this?
+  return new Promise((resolve) => {
+    setTimeout(() => {
+      resolve();
+    }, 2000);
+  })
+    .then(() => {
+      dispatch(resolveForgotPassword());
+      return true;
+    })
+    .catch((err) => {
+      dispatch(rejectForgotPassword(err));
+      return false;
+    });
+};
+
 // reducer
 export const reducer = handleActions(
   {
+    // Login flow
     [initLogin]: () => ({ ...initialState, isLoginPending: true }),
     [rejectLogin]: (state, action) => {
       return {
@@ -79,6 +105,24 @@ export const reducer = handleActions(
         loginErrors: initialState.loginErrors,
       };
     },
+    // Forgot password flow
+    [initForgotPassword]: () => ({
+      ...initialState,
+      isForgotPasswordPending: true,
+    }),
+    [rejectForgotPassword]: (state, action) => {
+      return {
+        ...state,
+        isForgotPasswordPending: false,
+        isForgotPasswordComplete: false,
+        forgotPasswordErrors: action.payload,
+      };
+    },
+    [resolveForgotPassword]: (state, action) => ({
+      ...state,
+      isForgotPasswordPending: false,
+      isForgotPasswordComplete: true,
+    }),
   },
   initialState
 );


### PR DESCRIPTION
@jmike just a work in progress for the forgot password flow.

Currently the `forgotPassword` exported method in `sessionStore` has a promise that just resolves true after 2 seconds. I guess we'll need to enhance Yeepclient? Or can I use the Yeep API directly there?