### PR TITLE
51: Dashboard UX

### DIFF
--- a/admin_ui/app/dashboard/DashboardOnboarding.js
+++ b/admin_ui/app/dashboard/DashboardOnboarding.js
@@ -1,9 +1,87 @@
 import React from 'react';
+import PropTypes from 'prop-types';
+import { Link } from '@reach/router';
 
-const DashboardOnboarding = () => {
+const DashboardOnboarding = ({ orgCount, permissionCount, roleCount, userCount }) => {
   return (
-    <p>Yay! onboard....</p>
+    <React.Fragment>
+      <p className="mb-4">
+        Welcome XXXX.
+        <br />
+        Not sure where to start? Follow these 4 steps below:
+      </p>
+      <OnboardingPane
+        number={1}
+        link="/organizations/create"
+        linkText="Create an organisation"
+        description='An organisation is the "umbrella" under which users, permissions (and roles) will be grouped. You can create as many organisations as you want. Users can belong to as many organisations as you see fit.'
+      />
+      <div className="rounded-lg p-4 flex md:items-center mb-4 bg-green-lightest">
+        <div className="mr-3 w-16 h-16 flex-none bg-green-dark flex rounded rounded-full justify-center items-center rounded">
+          <span className="text-3xl text-white">
+            <img src="/icon-yes-white.svg" width="36" height="29" alt="Checkmark" />
+          </span>
+        </div>
+        <div>
+          <Link to="organizations/create" className="text-2xl font-bold text-green-dark">
+            Create an organisation
+          </Link>
+          <p className="text-green-dark md:float-right">Great! 10 permissions have been created</p>
+          <p>
+            An organisation is the &quot;umbrella&quot; under which users, permissions (and roles)
+            will be grouped. You can create as many organisations as you want. Users can belong to
+            as many organisations as you see fit.
+          </p>
+        </div>
+      </div>
+      <p>
+        {orgCount} - {permissionCount} - {roleCount} - {userCount}
+      </p>
+    </React.Fragment>
   );
 };
 
+DashboardOnboarding.propTypes = {
+  orgCount: PropTypes.number,
+  permissionCount: PropTypes.number,
+  roleCount: PropTypes.number,
+  userCount: PropTypes.number,
+};
+
 export default DashboardOnboarding;
+
+const OnboardingPane = ({ number, link, linkText, description, successText }) => {
+  return (
+    <div className="border border-grey rounded-lg p-4 flex md:items-center mb-4">
+      <OnboardingNumber number={number} />
+      <div>
+        <Link to={link} className="text-2xl font-bold">
+          {linkText}
+        </Link>
+        <p>{description}</p>
+      </div>
+    </div>
+  );
+};
+OnboardingPane.propTypes = {
+  number: PropTypes.number.isRequired,
+  link: PropTypes.string.isRequired,
+  linkText: PropTypes.string.isRequired,
+  description: PropTypes.string.isRequired,
+  successText: PropTypes.string
+};
+
+/**
+ * Helper sub-component, outputs the large number-in-a-circle inside each OnboardingPane
+ * @param number
+ */
+const OnboardingNumber = ({ number }) => {
+  return (
+    <div className="mr-3 w-16 h-16 flex-none bg-grey flex rounded rounded-full justify-center items-center rounded">
+      <span className="text-3xl text-white">{number}</span>
+    </div>
+  );
+};
+OnboardingNumber.propTypes = {
+  number: PropTypes.number.isRequired,
+};

--- a/admin_ui/app/dashboard/DashboardOnboarding.js
+++ b/admin_ui/app/dashboard/DashboardOnboarding.js
@@ -74,9 +74,9 @@ const OnboardingPane = ({ number, link, linkText, description, successText = nul
     >
       <div
         className={classNames(
-          'mr-3',
-          'w-16',
-          'h-16',
+          'mr-4',
+          'w-12',
+          'h-12',
           'flex-none',
           'flex',
           'rounded',
@@ -93,7 +93,7 @@ const OnboardingPane = ({ number, link, linkText, description, successText = nul
       >
         <span className="text-3xl text-white">
           {successText ? (
-            <img src="/icon-yes-white.svg" width="36" height="29" alt="Checkmark" />
+            <img src="/icon-yes-white.svg" width="26" alt="Checkmark" />
           ) : (
             number
           )}

--- a/admin_ui/app/dashboard/DashboardOnboarding.js
+++ b/admin_ui/app/dashboard/DashboardOnboarding.js
@@ -92,11 +92,7 @@ const OnboardingPane = ({ number, link, linkText, description, successText = nul
         )}
       >
         <span className="text-3xl text-white">
-          {successText ? (
-            <img src="/icon-yes-white.svg" width="26" alt="Checkmark" />
-          ) : (
-            number
-          )}
+          {successText ? <img src="/icon-yes-white.svg" width="26" alt="Checkmark" /> : number}
         </span>
       </div>
       <div>

--- a/admin_ui/app/dashboard/DashboardOnboarding.js
+++ b/admin_ui/app/dashboard/DashboardOnboarding.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Link } from '@reach/router';
+import classNames from 'classnames';
 
 const DashboardOnboarding = ({ orgCount, permissionCount, roleCount, userCount }) => {
   return (
@@ -15,28 +16,29 @@ const DashboardOnboarding = ({ orgCount, permissionCount, roleCount, userCount }
         link="/organizations/create"
         linkText="Create an organisation"
         description='An organisation is the "umbrella" under which users, permissions (and roles) will be grouped. You can create as many organisations as you want. Users can belong to as many organisations as you see fit.'
+        successText={orgCount ? `${orgCount} organisations have been created` : null}
       />
-      <div className="rounded-lg p-4 flex md:items-center mb-4 bg-green-lightest">
-        <div className="mr-3 w-16 h-16 flex-none bg-green-dark flex rounded rounded-full justify-center items-center rounded">
-          <span className="text-3xl text-white">
-            <img src="/icon-yes-white.svg" width="36" height="29" alt="Checkmark" />
-          </span>
-        </div>
-        <div>
-          <Link to="organizations/create" className="text-2xl font-bold text-green-dark">
-            Create an organisation
-          </Link>
-          <p className="text-green-dark md:float-right">Great! 10 permissions have been created</p>
-          <p>
-            An organisation is the &quot;umbrella&quot; under which users, permissions (and roles)
-            will be grouped. You can create as many organisations as you want. Users can belong to
-            as many organisations as you see fit.
-          </p>
-        </div>
-      </div>
-      <p>
-        {orgCount} - {permissionCount} - {roleCount} - {userCount}
-      </p>
+      <OnboardingPane
+        number={2}
+        link="/permissions/create"
+        linkText="Create one (or more) permissions"
+        description='A permission is meant to be assigned to a user and help you identify what they can and can not do. Permissions can be scoped to an organisation or be "global". For example, a "Blog" organisation would most probably have permissions like "blog_read", "blog_write", "blog_administer".'
+        successText={permissionCount ? `${permissionCount} permissions have been created` : null}
+      />
+      <OnboardingPane
+        number={3}
+        link="/roles/create"
+        linkText="Create roles (optional step)"
+        description='A role is a grouping of permissions and allows an admin to quickly assign multiple permissions to a user. For example, a "Blog editor" role could contain the "blog_read" and "blog_write" permissions but not a "blog_administer" one.'
+        successText={roleCount ? `${roleCount} roles have been created` : null}
+      />
+      <OnboardingPane
+        number={4}
+        link="/users/create"
+        linkText="Create (or invite) users"
+        description="Finally you can create your users and assign them to one or more organisations with the appropriate roles and / or permissions. You can also partially create profiles and invite the users via email to log in and create their profiles."
+        successText={userCount ? `${userCount} users have been created` : null}
+      />
     </React.Fragment>
   );
 };
@@ -50,14 +52,62 @@ DashboardOnboarding.propTypes = {
 
 export default DashboardOnboarding;
 
-const OnboardingPane = ({ number, link, linkText, description, successText }) => {
+const OnboardingPane = ({ number, link, linkText, description, successText = null }) => {
   return (
-    <div className="border border-grey rounded-lg p-4 flex md:items-center mb-4">
-      <OnboardingNumber number={number} />
+    <div
+      className={classNames(
+        {
+          border: successText === null,
+          'border-grey': successText === null,
+        },
+        {
+          'bg-green-lightest': successText !== null,
+        },
+        'rounded-lg',
+        'p-4',
+        'flex',
+        'md:items-center',
+        'mb-4'
+      )}
+    >
+      <div
+        className={classNames(
+          'mr-3',
+          'w-16',
+          'h-16',
+          'flex-none',
+          'flex',
+          'rounded',
+          'rounded-full',
+          'justify-center',
+          'items-center',
+          {
+            'bg-grey': successText === null,
+          },
+          {
+            'bg-green-dark': successText !== null,
+          }
+        )}
+      >
+        <span className="text-3xl text-white">
+          {successText ? (
+            <img src="/icon-yes-white.svg" width="36" height="29" alt="Checkmark" />
+          ) : (
+            number
+          )}
+        </span>
+      </div>
       <div>
-        <Link to={link} className="text-2xl font-bold">
+        <Link
+          to={link}
+          className={classNames('text-2xl', 'font-bold', {
+            'text-green-dark': successText,
+            'hover:text-green-darker': successText,
+          })}
+        >
           {linkText}
         </Link>
+        {successText && <p className="text-green-dark md:float-right">{successText}</p>}
         <p>{description}</p>
       </div>
     </div>
@@ -68,20 +118,5 @@ OnboardingPane.propTypes = {
   link: PropTypes.string.isRequired,
   linkText: PropTypes.string.isRequired,
   description: PropTypes.string.isRequired,
-  successText: PropTypes.string
-};
-
-/**
- * Helper sub-component, outputs the large number-in-a-circle inside each OnboardingPane
- * @param number
- */
-const OnboardingNumber = ({ number }) => {
-  return (
-    <div className="mr-3 w-16 h-16 flex-none bg-grey flex rounded rounded-full justify-center items-center rounded">
-      <span className="text-3xl text-white">{number}</span>
-    </div>
-  );
-};
-OnboardingNumber.propTypes = {
-  number: PropTypes.number.isRequired,
+  successText: PropTypes.string,
 };

--- a/admin_ui/app/dashboard/DashboardOnboarding.js
+++ b/admin_ui/app/dashboard/DashboardOnboarding.js
@@ -2,9 +2,15 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { Link } from '@reach/router';
 import classNames from 'classnames';
-import { useSelector } from 'react-redux';
+import { useSelector, useDispatch } from 'react-redux';
+import { hideOnboarding } from '../session/sessionStore';
 
 const DashboardOnboarding = ({ orgCount, permissionCount, roleCount, userCount }) => {
+  const dispatch = useDispatch();
+  const onOnboardingOptOutClick = () => {
+    dispatch(hideOnboarding());
+  };
+
   const user = useSelector((state) => state.session.user);
   return (
     <React.Fragment>
@@ -41,6 +47,11 @@ const DashboardOnboarding = ({ orgCount, permissionCount, roleCount, userCount }
         description="Finally you can create your users and assign them to one or more organisations with the appropriate roles and / or permissions. You can also partially create profiles and invite the users via email to log in and create their profiles."
         successText={userCount ? `${userCount} users have been created` : null}
       />
+      <p>
+        <button className="pseudolink" onClick={onOnboardingOptOutClick}>
+          Hide this welcome page
+        </button>
+      </p>
     </React.Fragment>
   );
 };

--- a/admin_ui/app/dashboard/DashboardOnboarding.js
+++ b/admin_ui/app/dashboard/DashboardOnboarding.js
@@ -2,12 +2,14 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { Link } from '@reach/router';
 import classNames from 'classnames';
+import { useSelector } from 'react-redux';
 
 const DashboardOnboarding = ({ orgCount, permissionCount, roleCount, userCount }) => {
+  const user = useSelector((state) => state.session.user);
   return (
     <React.Fragment>
       <p className="mb-4">
-        Welcome XXXX.
+        Welcome <strong>{user.fullName}</strong>.
         <br />
         Not sure where to start? Follow these 4 steps below:
       </p>

--- a/admin_ui/app/dashboard/DashboardOnboarding.js
+++ b/admin_ui/app/dashboard/DashboardOnboarding.js
@@ -1,0 +1,9 @@
+import React from 'react';
+
+const DashboardOnboarding = () => {
+  return (
+    <p>Yay! onboard....</p>
+  );
+};
+
+export default DashboardOnboarding;

--- a/admin_ui/app/dashboard/DashboardPage.js
+++ b/admin_ui/app/dashboard/DashboardPage.js
@@ -112,7 +112,14 @@ const DashboardPage = () => {
         !roleCountLoading &&
         !permissionCountLoading &&
         !userCountLoading &&
-        (userCount === 0 || orgCount === 0) && <DashboardOnboarding />}
+        (userCount === 0 || orgCount === 0) && (
+          <DashboardOnboarding
+            orgCount={orgCount}
+            permissionCount={permissionCount}
+            roleCount={roleCount}
+            userCount={userCount}
+          />
+        )}
     </div>
   );
 };

--- a/admin_ui/app/dashboard/DashboardPage.js
+++ b/admin_ui/app/dashboard/DashboardPage.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 import useDocumentTitle from '@rehooks/document-title';
 import { useSelector } from 'react-redux';
 import IconOrganisation from '../../icons/IconOrganisation';
@@ -8,26 +7,9 @@ import ButtonLink from '../../components/ButtonLink';
 import IconPermission from '../../icons/IconPermission';
 import IconRole from '../../icons/IconRole';
 
-// TODO: Fetch actual data and replace this
-const dummyOrgs = [
-  {
-    id: 1,
-    name: 'Our Tech Blog',
-    users: 10,
-    activeSessions: 0,
-    roles: 2,
-  },
-  {
-    id: 2,
-    name: 'Zoho CRM',
-    users: 30,
-    activeSessions: 1,
-    roles: 7,
-  },
-];
-
 const DashboardPage = () => {
   useDocumentTitle('Dashboard');
+
   const userFullName = useSelector((state) => state.session.user.fullName);
   return (
     <div className="leading-normal p-4 sm:p-8 max-w-2xl sm:h-full">

--- a/admin_ui/app/dashboard/DashboardPage.js
+++ b/admin_ui/app/dashboard/DashboardPage.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import useDocumentTitle from '@rehooks/document-title';
+import DashboardOnboarding from './DashboardOnboarding';
 import IconOrganisation from '../../icons/IconOrganisation';
 import IconUser from '../../icons/IconUser';
 import ButtonLink from '../../components/ButtonLink';
@@ -13,8 +14,6 @@ import Spinner from '../../components/Spinner';
 
 const DashboardPage = () => {
   useDocumentTitle('Dashboard');
-  console.log('render!');
-
   const dispatch = useDispatch();
 
   // TODO:
@@ -28,7 +27,9 @@ const DashboardPage = () => {
   const permissionCount = useSelector((state) => state.permission.list.totalCount);
   // TODO: Populate the two varibles beow with proper selectors
   //  once branch user-adminui-management is merged
-  const userCountLoading = true;
+  const userCountLoading = false;
+  // Temporary: Change to 1 to view the "normal" dashboard view.
+  // Keep as 0 to view the onboarding UI
   const userCount = 0;
 
   React.useEffect(() => {
@@ -42,60 +43,76 @@ const DashboardPage = () => {
   return (
     <div className="leading-normal p-4 sm:p-8 max-w-2xl sm:h-full">
       <h1 className="mb-4 font-semibold text-3xl">Dashboard</h1>
-      <p className="mb-4">
-        Welcome <strong>{userFullName}</strong>. You Yeep installation is currently helping you
-        manage the following:
-      </p>
-      <div className="sm:flex flex-wrap">
-        <div className="border border-grey rounded p-4 sm:mr-4 flex-auto mb-4 text-center">
-          <IconOrganisation className="inline-block mb-4" color="#8492A6" height={44} />
-          <h2 className="mb-4 text-2xl">
-            {orgCountLoading && <Spinner size={36} className="ml-auto mr-auto" />}
-            {!orgCountLoading && (
-              <React.Fragment>
-                <strong>{orgCount}</strong> organizations
-              </React.Fragment>
-            )}
-          </h2>
-          <ButtonLink to="organizations">View all organizations</ButtonLink>
-        </div>
-        <div className="border border-grey rounded p-4 sm:mr-4 flex-auto mb-4 text-center">
-          <IconUser className="inline-block mb-4" color="#8492A6" height={44} />
-          <h2 className="mb-4 text-2xl">
-            {userCountLoading && <Spinner size={36} className="ml-auto mr-auto" />}
-            {!userCountLoading && (
-              <React.Fragment>
-                <strong>{userCount}</strong> users
-              </React.Fragment>
-            )}
-          </h2>
-          <ButtonLink to="users">View all users</ButtonLink>
-        </div>
-        <div className="border border-grey rounded p-4 sm:mr-4 flex-auto mb-4 text-center">
-          <IconPermission className="inline-block mb-4" color="#8492A6" height={44} />
-          <h2 className="mb-4 text-2xl">
-            {permissionCountLoading && <Spinner size={36} className="ml-auto mr-auto" />}
-            {!permissionCountLoading && (
-              <React.Fragment>
-                <strong>{permissionCount}</strong> permissions
-              </React.Fragment>
-            )}
-          </h2>
-          <ButtonLink to="permissions">View all permissions</ButtonLink>
-        </div>
-        <div className="border border-grey rounded p-4 sm:mr-4 flex-auto mb-4 text-center">
-          <IconRole className="inline-block mb-4" color="#8492A6" height={44} />
-          <h2 className="mb-4 text-2xl">
-            {roleCountLoading && <Spinner size={36} className="ml-auto mr-auto" />}
-            {!roleCountLoading && (
-              <React.Fragment>
-                <strong>{roleCount}</strong> roles
-              </React.Fragment>
-            )}
-          </h2>
-          <ButtonLink to="roles">View all roles</ButtonLink>
-        </div>
-      </div>
+      {(orgCountLoading || roleCountLoading || permissionCountLoading || userCountLoading) && (
+        <Spinner className="ml-auto mr-auto" />
+      )}
+      {!orgCountLoading &&
+        !roleCountLoading &&
+        !permissionCountLoading &&
+        !userCountLoading &&
+        (userCount > 0 && orgCount > 0) && (
+          <React.Fragment>
+            <p className="mb-4">
+              Welcome <strong>{userFullName}</strong>. You Yeep installation is currently helping
+              you manage the following:
+            </p>
+            <div className="sm:flex flex-wrap">
+              <div className="border border-grey rounded p-4 sm:mr-4 flex-auto mb-4 text-center">
+                <IconOrganisation className="inline-block mb-4" color="#8492A6" height={44} />
+                <h2 className="mb-4 text-2xl">
+                  {orgCountLoading && <Spinner size={36} className="ml-auto mr-auto" />}
+                  {!orgCountLoading && (
+                    <React.Fragment>
+                      <strong>{orgCount}</strong> organizations
+                    </React.Fragment>
+                  )}
+                </h2>
+                <ButtonLink to="organizations">View all organizations</ButtonLink>
+              </div>
+              <div className="border border-grey rounded p-4 sm:mr-4 flex-auto mb-4 text-center">
+                <IconUser className="inline-block mb-4" color="#8492A6" height={44} />
+                <h2 className="mb-4 text-2xl">
+                  {userCountLoading && <Spinner size={36} className="ml-auto mr-auto" />}
+                  {!userCountLoading && (
+                    <React.Fragment>
+                      <strong>{userCount}</strong> users
+                    </React.Fragment>
+                  )}
+                </h2>
+                <ButtonLink to="users">View all users</ButtonLink>
+              </div>
+              <div className="border border-grey rounded p-4 sm:mr-4 flex-auto mb-4 text-center">
+                <IconPermission className="inline-block mb-4" color="#8492A6" height={44} />
+                <h2 className="mb-4 text-2xl">
+                  {permissionCountLoading && <Spinner size={36} className="ml-auto mr-auto" />}
+                  {!permissionCountLoading && (
+                    <React.Fragment>
+                      <strong>{permissionCount}</strong> permissions
+                    </React.Fragment>
+                  )}
+                </h2>
+                <ButtonLink to="permissions">View all permissions</ButtonLink>
+              </div>
+              <div className="border border-grey rounded p-4 sm:mr-4 flex-auto mb-4 text-center">
+                <IconRole className="inline-block mb-4" color="#8492A6" height={44} />
+                <h2 className="mb-4 text-2xl">
+                  {roleCountLoading && <Spinner size={36} className="ml-auto mr-auto" />}
+                  {!roleCountLoading && (
+                    <React.Fragment>
+                      <strong>{roleCount}</strong> roles
+                    </React.Fragment>
+                  )}
+                </h2>
+                <ButtonLink to="roles">View all roles</ButtonLink>
+              </div>
+            </div>
+          </React.Fragment>
+        )}
+      {!orgCountLoading &&
+        !roleCountLoading &&
+        !permissionCountLoading &&
+        !userCountLoading &&
+        (userCount === 0 || orgCount === 0) && <DashboardOnboarding />}
     </div>
   );
 };

--- a/admin_ui/app/dashboard/DashboardPage.js
+++ b/admin_ui/app/dashboard/DashboardPage.js
@@ -1,14 +1,34 @@
 import React from 'react';
 import useDocumentTitle from '@rehooks/document-title';
-import { useSelector } from 'react-redux';
 import IconOrganisation from '../../icons/IconOrganisation';
 import IconUser from '../../icons/IconUser';
 import ButtonLink from '../../components/ButtonLink';
 import IconPermission from '../../icons/IconPermission';
 import IconRole from '../../icons/IconRole';
+import { useSelector, useDispatch } from 'react-redux';
+import { listOrgs } from '../org/orgStore';
+import { listPermissions } from '../permission/permissionStore';
+import { listRoles } from '../role/roleStore';
+import Spinner from '../../components/Spinner';
 
 const DashboardPage = () => {
   useDocumentTitle('Dashboard');
+  console.log('render!');
+
+  const orgCountLoading = useSelector((state) => state.org.list.isLoading);
+  const orgCount = useSelector((state) => state.org.list.totalCount);
+  const roleCountLoading = useSelector((state) => state.role.list.isLoading);
+  const roleCount = useSelector((state) => state.role.list.totalCount);
+  const permissionCountLoading = useSelector((state) => state.permission.list.isLoading);
+  const permissionCount = useSelector((state) => state.permission.list.totalCount);
+  const dispatch = useDispatch();
+
+  React.useEffect(() => {
+    // On component mount, load counts for all orgs
+    dispatch(listOrgs());
+    dispatch(listRoles());
+    dispatch(listPermissions());
+  }, [dispatch]);
 
   const userFullName = useSelector((state) => state.session.user.fullName);
   return (
@@ -22,7 +42,12 @@ const DashboardPage = () => {
         <div className="border border-grey rounded p-4 sm:mr-4 flex-auto mb-4 text-center">
           <IconOrganisation className="inline-block mb-4" color="#8492A6" height={44} />
           <h2 className="mb-4 text-2xl">
-            <strong>???</strong> organisations
+            {orgCountLoading && <Spinner size="36" />}
+            {!orgCountLoading && (
+              <React.Fragment>
+                <strong>{orgCount}</strong> organizations
+              </React.Fragment>
+            )}
           </h2>
           <ButtonLink to="organizations">View all organizations</ButtonLink>
         </div>
@@ -36,14 +61,24 @@ const DashboardPage = () => {
         <div className="border border-grey rounded p-4 sm:mr-4 flex-auto mb-4 text-center">
           <IconPermission className="inline-block mb-4" color="#8492A6" height={44} />
           <h2 className="mb-4 text-2xl">
-            <strong>???</strong> permissions
+            {permissionCountLoading && <Spinner size="36" />}
+            {!permissionCountLoading && (
+              <React.Fragment>
+                <strong>{permissionCount}</strong> permissions
+              </React.Fragment>
+            )}
           </h2>
           <ButtonLink to="permissions">View all permissions</ButtonLink>
         </div>
         <div className="border border-grey rounded p-4 sm:mr-4 flex-auto mb-4 text-center">
           <IconRole className="inline-block mb-4" color="#8492A6" height={44} />
           <h2 className="mb-4 text-2xl">
-            <strong>???</strong> roles
+            {roleCountLoading && <Spinner size="36" />}
+            {!roleCountLoading && (
+              <React.Fragment>
+                <strong>{roleCount}</strong> roles
+              </React.Fragment>
+            )}
           </h2>
           <ButtonLink to="roles">View all roles</ButtonLink>
         </div>

--- a/admin_ui/app/dashboard/DashboardPage.js
+++ b/admin_ui/app/dashboard/DashboardPage.js
@@ -25,12 +25,15 @@ const DashboardPage = () => {
   const roleCount = useSelector((state) => state.role.list.totalCount);
   const permissionCountLoading = useSelector((state) => state.permission.list.isLoading);
   const permissionCount = useSelector((state) => state.permission.list.totalCount);
-  // TODO: Populate the two varibles beow with proper selectors
+  // TODO: Populate the two varibles below with proper selectors
   //  once branch user-adminui-management is merged
   const userCountLoading = false;
   // Temporary: Change to 1 to view the "normal" dashboard view.
   // Keep as 0 to view the onboarding UI
   const userCount = 0;
+
+  // The user might have opted to hide the onboarding page
+  const hideOnboarding = useSelector((state) => state.session.hideOnboarding);
 
   React.useEffect(() => {
     // On component mount, load counts for all orgs
@@ -50,7 +53,7 @@ const DashboardPage = () => {
         !roleCountLoading &&
         !permissionCountLoading &&
         !userCountLoading &&
-        (userCount > 0 && orgCount > 0) && (
+        ((userCount > 0 && orgCount > 0) || hideOnboarding) && (
           <React.Fragment>
             <p className="mb-4">
               Welcome <strong>{userFullName}</strong>. You Yeep installation is currently helping
@@ -112,7 +115,7 @@ const DashboardPage = () => {
         !roleCountLoading &&
         !permissionCountLoading &&
         !userCountLoading &&
-        (userCount === 0 || orgCount === 0) && (
+        ((userCount === 0 || orgCount === 0) && !hideOnboarding) && (
           <DashboardOnboarding
             orgCount={orgCount}
             permissionCount={permissionCount}

--- a/admin_ui/app/dashboard/DashboardPage.js
+++ b/admin_ui/app/dashboard/DashboardPage.js
@@ -1,8 +1,12 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import useDocumentTitle from '@rehooks/document-title';
-import { Link } from '@reach/router';
+import { useSelector } from 'react-redux';
 import IconOrganisation from '../../icons/IconOrganisation';
+import IconUser from '../../icons/IconUser';
+import ButtonLink from '../../components/ButtonLink';
+import IconPermission from '../../icons/IconPermission';
+import IconRole from '../../icons/IconRole';
 
 // TODO: Fetch actual data and replace this
 const dummyOrgs = [
@@ -22,59 +26,45 @@ const dummyOrgs = [
   },
 ];
 
-const DashboardOrgCard = (props) => {
-  return (
-    <div className="border border-grey rounded p-4 flex-1 mb-4 sm:mr-4 relative">
-      <h2 className="mb-4 font-bold text-2xl">
-        <Link to={`/organizations/${props.id}/edit`}>{props.name}</Link>
-      </h2>
-      <IconOrganisation className="absolute top-0 right-0 mt-4 mr-4" height={28} />
-      <table className="w-full">
-        <tbody>
-          <tr>
-            <td>Total users:</td>
-            <td className="text-right">
-              <Link to="/users">{props.users}</Link>
-            </td>
-          </tr>
-          <tr>
-            <td>Active sessions:</td>
-            <td className="text-right">{props.activeSessions}</td>
-          </tr>
-          <tr>
-            <td>Org-specific roles:</td>
-            <td className="text-right">
-              <Link to="/roles">{props.roles}</Link>
-            </td>
-          </tr>
-        </tbody>
-      </table>
-    </div>
-  );
-};
-DashboardOrgCard.propTypes = {
-  id: PropTypes.number.isRequired,
-  name: PropTypes.string.isRequired,
-  users: PropTypes.number,
-  activeSessions: PropTypes.number,
-  roles: PropTypes.number,
-};
-
 const DashboardPage = () => {
   useDocumentTitle('Dashboard');
+  const userFullName = useSelector((state) => state.session.user.fullName);
   return (
     <div className="leading-normal p-4 sm:p-8 max-w-2xl sm:h-full">
       <h1 className="mb-4 font-semibold text-3xl">Dashboard</h1>
       <p className="mb-4">
-        Welcome <strong>Jane Doe</strong>. You are managing <strong>40</strong> users across{' '}
-        <strong>2</strong> organisations:
+        Welcome <strong>{userFullName}</strong>. You Yeep installation is currently helping you
+        manage the following:
       </p>
-      <div className="sm:flex">
-        <DashboardOrgCard {...dummyOrgs[0]} />
-        <DashboardOrgCard {...dummyOrgs[1]} />
-      </div>
-      <div className="bg-yellow-lighter rounded p-4">
-        <strong>Tip:</strong> Some helpful message to appear here
+      <div className="sm:flex flex-wrap">
+        <div className="border border-grey rounded p-4 sm:mr-4 flex-auto mb-4 text-center">
+          <IconOrganisation className="inline-block mb-4" color="#8492A6" height={44} />
+          <h2 className="mb-4 text-2xl">
+            <strong>???</strong> organisations
+          </h2>
+          <ButtonLink to="organizations">View all organizations</ButtonLink>
+        </div>
+        <div className="border border-grey rounded p-4 sm:mr-4 flex-auto mb-4 text-center">
+          <IconUser className="inline-block mb-4" color="#8492A6" height={44} />
+          <h2 className="mb-4 text-2xl">
+            <strong>???</strong> users
+          </h2>
+          <ButtonLink to="users">View all users</ButtonLink>
+        </div>
+        <div className="border border-grey rounded p-4 sm:mr-4 flex-auto mb-4 text-center">
+          <IconPermission className="inline-block mb-4" color="#8492A6" height={44} />
+          <h2 className="mb-4 text-2xl">
+            <strong>???</strong> permissions
+          </h2>
+          <ButtonLink to="permissions">View all permissions</ButtonLink>
+        </div>
+        <div className="border border-grey rounded p-4 sm:mr-4 flex-auto mb-4 text-center">
+          <IconRole className="inline-block mb-4" color="#8492A6" height={44} />
+          <h2 className="mb-4 text-2xl">
+            <strong>???</strong> roles
+          </h2>
+          <ButtonLink to="roles">View all roles</ButtonLink>
+        </div>
       </div>
     </div>
   );

--- a/admin_ui/app/dashboard/DashboardPage.js
+++ b/admin_ui/app/dashboard/DashboardPage.js
@@ -15,13 +15,21 @@ const DashboardPage = () => {
   useDocumentTitle('Dashboard');
   console.log('render!');
 
+  const dispatch = useDispatch();
+
+  // TODO:
+  //  Loading all data for 3 models (4 after users are ready) is a bit redundant.
+  //  Consider implementing a .getCounts() API call
   const orgCountLoading = useSelector((state) => state.org.list.isLoading);
   const orgCount = useSelector((state) => state.org.list.totalCount);
   const roleCountLoading = useSelector((state) => state.role.list.isLoading);
   const roleCount = useSelector((state) => state.role.list.totalCount);
   const permissionCountLoading = useSelector((state) => state.permission.list.isLoading);
   const permissionCount = useSelector((state) => state.permission.list.totalCount);
-  const dispatch = useDispatch();
+  // TODO: Populate the two varibles beow with proper selectors
+  //  once branch user-adminui-management is merged
+  const userCountLoading = true;
+  const userCount = 0;
 
   React.useEffect(() => {
     // On component mount, load counts for all orgs
@@ -42,7 +50,7 @@ const DashboardPage = () => {
         <div className="border border-grey rounded p-4 sm:mr-4 flex-auto mb-4 text-center">
           <IconOrganisation className="inline-block mb-4" color="#8492A6" height={44} />
           <h2 className="mb-4 text-2xl">
-            {orgCountLoading && <Spinner size="36" />}
+            {orgCountLoading && <Spinner size={36} className="ml-auto mr-auto" />}
             {!orgCountLoading && (
               <React.Fragment>
                 <strong>{orgCount}</strong> organizations
@@ -54,14 +62,19 @@ const DashboardPage = () => {
         <div className="border border-grey rounded p-4 sm:mr-4 flex-auto mb-4 text-center">
           <IconUser className="inline-block mb-4" color="#8492A6" height={44} />
           <h2 className="mb-4 text-2xl">
-            <strong>???</strong> users
+            {userCountLoading && <Spinner size={36} className="ml-auto mr-auto" />}
+            {!userCountLoading && (
+              <React.Fragment>
+                <strong>{userCount}</strong> users
+              </React.Fragment>
+            )}
           </h2>
           <ButtonLink to="users">View all users</ButtonLink>
         </div>
         <div className="border border-grey rounded p-4 sm:mr-4 flex-auto mb-4 text-center">
           <IconPermission className="inline-block mb-4" color="#8492A6" height={44} />
           <h2 className="mb-4 text-2xl">
-            {permissionCountLoading && <Spinner size="36" />}
+            {permissionCountLoading && <Spinner size={36} className="ml-auto mr-auto" />}
             {!permissionCountLoading && (
               <React.Fragment>
                 <strong>{permissionCount}</strong> permissions
@@ -73,7 +86,7 @@ const DashboardPage = () => {
         <div className="border border-grey rounded p-4 sm:mr-4 flex-auto mb-4 text-center">
           <IconRole className="inline-block mb-4" color="#8492A6" height={44} />
           <h2 className="mb-4 text-2xl">
-            {roleCountLoading && <Spinner size="36" />}
+            {roleCountLoading && <Spinner size={36} className="ml-auto mr-auto" />}
             {!roleCountLoading && (
               <React.Fragment>
                 <strong>{roleCount}</strong> roles

--- a/admin_ui/app/org/orgStore.js
+++ b/admin_ui/app/org/orgStore.js
@@ -8,7 +8,8 @@ import parseYeepValidationErrors from '../../utilities/parseYeepValidationErrors
 export const initialState = {
   list: {
     records: [],
-    totalCount: 0,
+    // Initialise to "null" cause 0 is actually meaningfull
+    totalCount: null,
     limit: 10,
     isLoading: false,
     cursors: [],

--- a/admin_ui/app/permission/permissionStore.js
+++ b/admin_ui/app/permission/permissionStore.js
@@ -7,7 +7,7 @@ import parseYeepValidationErrors from '../../utilities/parseYeepValidationErrors
 export const initialState = {
   list: {
     records: [],
-    totalCount: 0,
+    totalCount: null,
     limit: 10,
     isLoading: false,
     cursors: [],

--- a/admin_ui/app/role/roleStore.js
+++ b/admin_ui/app/role/roleStore.js
@@ -7,7 +7,7 @@ import parseYeepValidationErrors from '../../utilities/parseYeepValidationErrors
 export const initialState = {
   list: {
     records: [],
-    totalCount: 0,
+    totalCount: null,
     limit: 10,
     isLoading: false,
     cursors: [],

--- a/admin_ui/app/session/sessionStore.js
+++ b/admin_ui/app/session/sessionStore.js
@@ -7,6 +7,7 @@ export const initialState = {
   user: {},
   loginErrors: {},
   isLoginPending: false,
+  hideOnboarding: false,
 };
 
 // actions
@@ -18,6 +19,8 @@ const rejectLogin = createAction('LOGIN_REJECT');
 export const resetLoginErrors = createAction('LOGIN_RESET_ERRORS');
 const initLogout = createAction('LOGOUT_INIT');
 export const resolveLogout = createAction('LOGOUT_RESOLVE');
+// Users can tap "Hide this welcome page" on the <DashboardOnboaring /> page
+export const hideOnboarding = createAction('HIDE_ONBOARDING');
 
 export const login = (user, password) => (dispatch) => {
   dispatch(initLogin());
@@ -77,6 +80,12 @@ export const reducer = handleActions(
       return {
         ...state,
         loginErrors: initialState.loginErrors,
+      };
+    },
+    [hideOnboarding]: (state) => {
+      return {
+        ...state,
+        hideOnboarding: true,
       };
     },
   },

--- a/admin_ui/components/Spinner.js
+++ b/admin_ui/components/Spinner.js
@@ -1,11 +1,12 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import classNames from 'classnames';
 
-const Spinner = ({size}) => {
+const Spinner = ({size, className}) => {
   let borderWidth = parseInt(size / 10, 10);
   return (
     <React.Fragment>
-      <div className="spinner"/>
+      <div className={classNames(className, "spinner")}/>
       <style jsx>{`
         .spinner {
           background-color: rgba(255, 255, 255, 0.8);
@@ -43,7 +44,8 @@ const Spinner = ({size}) => {
 };
 
 Spinner.propTypes = {
-  size: PropTypes.number
+  size: PropTypes.number,
+  className: PropTypes.string
 };
 
 Spinner.defaultProps = {

--- a/admin_ui/components/Spinner.js
+++ b/admin_ui/components/Spinner.js
@@ -1,0 +1,53 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+const Spinner = ({size}) => {
+  let borderWidth = parseInt(size / 10, 10);
+  return (
+    <React.Fragment>
+      <div className="spinner"/>
+      <style jsx>{`
+        .spinner {
+          background-color: rgba(255, 255, 255, 0.8);
+          // To ensure we're above any Select component
+          z-index: 2;
+        }
+        .spinner,
+        .spinner:after {
+          border-radius: 50%;
+          width: ${size}px;
+          height: ${size}px;
+        }
+        .spinner {
+          font-size: 10px;
+          position: relative;
+          text-indent: -9999em;
+          border-top: ${borderWidth}px solid rgba(0, 0, 0, 0.1);
+          border-right: ${borderWidth}px solid rgba(0, 0, 0, 0.1);
+          border-bottom: ${borderWidth}px solid rgba(0, 0, 0, 0.1);
+          border-left: ${borderWidth}px solid #ffffff;
+          transform: translateZ(0);
+          animation: load8 1.1s infinite linear;
+        }
+        @keyframes load8 {
+          0% {
+            transform: rotate(0deg);
+          }
+          100% {
+            transform: rotate(360deg);
+          }
+        }
+      `}</style>
+    </React.Fragment>
+  );
+};
+
+Spinner.propTypes = {
+  size: PropTypes.number
+};
+
+Spinner.defaultProps = {
+  size: 88
+};
+
+export default Spinner;

--- a/admin_ui/public/icon-yes-white.svg
+++ b/admin_ui/public/icon-yes-white.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 18 14.4"><path fill="#FFFFFF" d="M6.48 8.64l-3.6-3.6L0 7.92l3.6 3.6 2.88 2.88 2.88-2.88L18 2.88 15.12 0 6.48 8.64z" /></svg>


### PR DESCRIPTION
Implemented an "onboarding" helper page: If userCount == 0 || orgCount == 0 and the `store.session.hideOnboarding` flag has not been set, show `<DashboardOnboarding/>` which provides a bit more info about the steps needed to be taken as a new Yeep admin:

![image](https://user-images.githubusercontent.com/14941382/69012475-e4f4d000-097e-11ea-8801-9c4657ebd4bd.png)

Since @jmike's Users branch has not been merged yet, the `userCount` variable (see line 33 of `DashboardPage.js` is manually hardcoded to be 0 so we can see this page.