### PR TITLE
55: Role / Permission modal enchancements

### DIFF
--- a/admin_ui/app/org/OrgEditPermissionsTab.js
+++ b/admin_ui/app/org/OrgEditPermissionsTab.js
@@ -74,7 +74,7 @@ const OrgEditPermissionsTab = () => {
 
   return (
     <React.Fragment>
-      <PermissionCreateModal />
+      <PermissionCreateModal org={org} />
       <PermissionEditModal onSuccess={reload} />
       <PermissionDeleteModal onSuccess={reload} />
       <fieldset className="mb-6">

--- a/admin_ui/app/org/OrgEditRolesTab.js
+++ b/admin_ui/app/org/OrgEditRolesTab.js
@@ -17,6 +17,7 @@ import {
   setRoleDeleteRecord,
 } from '../role/roleStore';
 import yeepClient from '../yeepClient';
+import PermissionCreateModal from '../permission/PermissionCreateModal';
 
 const OrgEditRoleTab = () => {
   const org = useSelector((state) => state.org.update.record);
@@ -74,7 +75,7 @@ const OrgEditRoleTab = () => {
 
   return (
     <React.Fragment>
-      <RoleCreateModal />
+      <RoleCreateModal org={org} />
       <RoleEditModal onSuccess={reload} />
       <RoleDeleteModal onSuccess={reload} />
       <fieldset className="mb-6">

--- a/admin_ui/app/permission/PermissionCreateModal.js
+++ b/admin_ui/app/permission/PermissionCreateModal.js
@@ -10,7 +10,8 @@ import {
 import PermissionForm from './PermissionForm';
 import Modal from '../../components/Modal';
 
-const PermissionCreateModal = ({ onSuccess, onError }) => {
+const PermissionCreateModal = ({ onSuccess, onError, org }) => {
+
   const errors = useSelector((state) => state.permission.create.errors);
   const isSavePending = useSelector((state) => state.permission.create.isSavePending);
   const isDisplayed = useSelector((state) => state.permission.create.isDisplayed);
@@ -43,8 +44,23 @@ const PermissionCreateModal = ({ onSuccess, onError }) => {
     [dispatch, onError, onSuccess]
   );
 
+  // Create an empty record that we'll pass to <PermissionForm>
+  // via the default Values prop
+  let record = {};
+
   if (!isDisplayed) {
     return null;
+  } else {
+    // We will display the modal. If an org was passed in via props,
+    // send it down the line to <PermissionForm /> so that it shows that
+    // org as preselected
+    if (org.id) {
+      record = {
+        name: "",
+        description: "",
+        org
+      };
+    }
   }
 
   return (
@@ -55,6 +71,8 @@ const PermissionCreateModal = ({ onSuccess, onError }) => {
         errors={errors}
         onCancel={onDismiss}
         onSubmit={submitForm}
+        defaultValues={record}
+        lockOrgScope={true}
       />
     </Modal>
   );
@@ -63,6 +81,7 @@ const PermissionCreateModal = ({ onSuccess, onError }) => {
 PermissionCreateModal.propTypes = {
   onSuccess: PropTypes.func,
   onError: PropTypes.func,
+  org: PropTypes.object
 };
 
 PermissionCreateModal.defaultProps = {

--- a/admin_ui/app/permission/PermissionCreateModal.js
+++ b/admin_ui/app/permission/PermissionCreateModal.js
@@ -64,7 +64,7 @@ const PermissionCreateModal = ({ onSuccess, onError, org }) => {
   }
 
   return (
-    <Modal onClose={onDismiss}>
+    <Modal onClose={onDismiss} fullWidth={true}>
       <h1 className="font-semibold text-3xl mb-6">Create permission</h1>
       <PermissionForm
         isSavePending={isSavePending}

--- a/admin_ui/app/permission/PermissionEditModal.js
+++ b/admin_ui/app/permission/PermissionEditModal.js
@@ -49,7 +49,7 @@ const PermissionEditModal = ({ onSuccess, onError }) => {
   }
 
   return (
-    <Modal onClose={onDismiss}>
+    <Modal onClose={onDismiss} fullWidth={true}>
       <h1 className="font-semibold text-3xl mb-6">Edit permission {record.name}</h1>
       <PermissionForm
         defaultValues={record}

--- a/admin_ui/app/permission/PermissionForm.js
+++ b/admin_ui/app/permission/PermissionForm.js
@@ -22,7 +22,15 @@ function fetchOrgOptionsAsync(inputValue) {
   });
 }
 
-const PermissionForm = ({ defaultValues, isSavePending, errors, onSubmit, onCancel, onDelete }) => {
+const PermissionForm = ({
+  defaultValues,
+  isSavePending,
+  errors,
+  onSubmit,
+  onCancel,
+  onDelete,
+  lockOrgScope,
+}) => {
   const [values, setValues] = React.useState(defaultValues);
 
   const onFormSubmit = useCallback(
@@ -68,7 +76,10 @@ const PermissionForm = ({ defaultValues, isSavePending, errors, onSubmit, onCanc
           {errors.description && <p className="invalid mt-2">{errors.description}</p>}
         </div>
         <div className="form-group mb-4">
-          <label htmlFor="org">Organization scope (optional)</label>
+          <label htmlFor="org">
+            Organization scope
+            {!lockOrgScope && !values.id && <span> (optional)</span>}
+          </label>
           <AsyncSelect
             id="org"
             className="w-full sm:w-1/2"
@@ -83,7 +94,7 @@ const PermissionForm = ({ defaultValues, isSavePending, errors, onSubmit, onCanc
                 org: selectedOption ? OrgOption.fromOption(selectedOption).toRecord() : null,
               })
             }
-            isDisabled={isSavePending || values.id != null}
+            isDisabled={isSavePending || values.id != null || lockOrgScope}
           />
           {errors.org && <p className="text-red mt-2">{errors.org}</p>}
         </div>
@@ -120,6 +131,10 @@ PermissionForm.propTypes = {
   onCancel: PropTypes.func,
   onDelete: PropTypes.func,
   isSavePending: PropTypes.bool,
+  // Under certain circumstances we might not want the user to be able
+  // to chage a (pre-selected) organization scope
+  // (for example in the "Create permission" modal from with the edit org page
+  lockOrgScope: PropTypes.bool,
 };
 
 PermissionForm.defaultProps = {
@@ -129,6 +144,7 @@ PermissionForm.defaultProps = {
   onCancel: noop,
   onDelete: noop,
   isSavePending: false,
+  lockOrgScope: false,
 };
 
 export default PermissionForm;

--- a/admin_ui/app/role/RoleCreateModal.js
+++ b/admin_ui/app/role/RoleCreateModal.js
@@ -6,7 +6,7 @@ import { clearRoleCreateForm, hideRoleCreateForm, createRole } from './roleStore
 import RoleForm from './RoleForm';
 import Modal from '../../components/Modal';
 
-const RoleCreateModal = ({ onSuccess, onError }) => {
+const RoleCreateModal = ({ onSuccess, onError, org }) => {
   const errors = useSelector((state) => state.role.create.errors);
   const isSavePending = useSelector((state) => state.role.create.isSavePending);
   const isDisplayed = useSelector((state) => state.role.create.isDisplayed);
@@ -39,8 +39,23 @@ const RoleCreateModal = ({ onSuccess, onError }) => {
     [dispatch, onError, onSuccess]
   );
 
+  // Create an empty record that we'll pass to <Roleform>
+  // via the default Values prop
+  let record = {};
+
   if (!isDisplayed) {
     return null;
+  } else {
+    // We will display the modal. If an org was passed in via props,
+    // send it down the line to <PermissionForm /> so that it shows that
+    // org as preselected
+    if (org.id) {
+      record = {
+        name: "",
+        description: "",
+        org
+      };
+    }
   }
 
   return (
@@ -51,6 +66,8 @@ const RoleCreateModal = ({ onSuccess, onError }) => {
         errors={errors}
         onCancel={onDismiss}
         onSubmit={submitForm}
+        defaultValues={record}
+        lockOrgScope={true}
       />
     </Modal>
   );
@@ -59,6 +76,7 @@ const RoleCreateModal = ({ onSuccess, onError }) => {
 RoleCreateModal.propTypes = {
   onSuccess: PropTypes.func,
   onError: PropTypes.func,
+  org: PropTypes.object
 };
 
 RoleCreateModal.defaultProps = {

--- a/admin_ui/app/role/RoleCreateModal.js
+++ b/admin_ui/app/role/RoleCreateModal.js
@@ -59,7 +59,7 @@ const RoleCreateModal = ({ onSuccess, onError, org }) => {
   }
 
   return (
-    <Modal onClose={onDismiss}>
+    <Modal onClose={onDismiss} fullWidth={true}>
       <h1 className="font-semibold text-3xl mb-6">Create Role</h1>
       <RoleForm
         isSavePending={isSavePending}

--- a/admin_ui/app/role/RoleEditModal.js
+++ b/admin_ui/app/role/RoleEditModal.js
@@ -46,7 +46,7 @@ const RoleEditModal = ({ onSuccess, onError }) => {
   }
 
   return (
-    <Modal onClose={onDismiss}>
+    <Modal onClose={onDismiss} fullWidth={true}>
       <h1 className="font-semibold text-3xl mb-6">Edit role {record.name}</h1>
       <RoleForm
         defaultValues={record}

--- a/admin_ui/app/role/RoleForm.js
+++ b/admin_ui/app/role/RoleForm.js
@@ -37,7 +37,15 @@ function fetchPermissionOptionsAsync(inputValue) {
   });
 }
 
-const RoleForm = ({ defaultValues, isSavePending, errors, onSubmit, onCancel, onDelete }) => {
+const RoleForm = ({
+  defaultValues,
+  isSavePending,
+  errors,
+  onSubmit,
+  onCancel,
+  onDelete,
+  lockOrgScope,
+}) => {
   const [values, setValues] = React.useState(defaultValues);
 
   const onFormSubmit = useCallback(
@@ -83,7 +91,10 @@ const RoleForm = ({ defaultValues, isSavePending, errors, onSubmit, onCancel, on
           {errors.description && <p className="invalid mt-2">{errors.description}</p>}
         </div>
         <div className="form-group mb-4">
-          <label htmlFor="org">Organization scope (optional)</label>
+          <label htmlFor="org">
+            Organization scope
+            {!lockOrgScope && !values.id && <span> (optional)</span>}
+          </label>
           <AsyncSelect
             id="org"
             className="w-full sm:w-1/2"
@@ -98,7 +109,7 @@ const RoleForm = ({ defaultValues, isSavePending, errors, onSubmit, onCancel, on
                 org: selectedOption ? OrgOption.fromOption(selectedOption).toRecord() : null,
               })
             }
-            isDisabled={isSavePending || values.id != null}
+            isDisabled={isSavePending || values.id != null || lockOrgScope}
           />
           {errors.org && <p className="text-red mt-2">{errors.org}</p>}
         </div>
@@ -163,6 +174,10 @@ RoleForm.propTypes = {
   onCancel: PropTypes.func,
   onDelete: PropTypes.func,
   isSavePending: PropTypes.bool,
+  // Under certain circumstances we might not want the user to be able
+  // to chage a (pre-selected) organization scope
+  // (for example in the "Create role" modal from with the edit org page
+  lockOrgScope: PropTypes.bool,
 };
 
 RoleForm.defaultProps = {
@@ -172,6 +187,7 @@ RoleForm.defaultProps = {
   onCancel: noop,
   onDelete: noop,
   isSavePending: false,
+  lockOrgScope: false,
 };
 
 export default RoleForm;

--- a/admin_ui/components/Modal.js
+++ b/admin_ui/components/Modal.js
@@ -39,7 +39,7 @@ function Modal(props) {
           'modal',
           'w-full',
           'h-full',
-          // 'sm:w-auto',
+          {'sm:w-auto' : !props.fullWidth},
           'sm:h-auto',
           'max-w-lg',
           'relative',
@@ -74,8 +74,13 @@ function Modal(props) {
 Modal.propTypes = {
   // Parent component needs to send an onClose handler
   onClose: PropTypes.func.isRequired,
+  // If "fullWidth" prop is specified, sm:w-auto class will be removed
+  // so that the modal contents can greedily take the full width of the
+  // modal (up to .max-w-lg)
+  fullWidth: PropTypes.bool,
   className: PropTypes.string,
   children: PropTypes.node,
+
 };
 
 export default Modal;

--- a/admin_ui/components/Modal.js
+++ b/admin_ui/components/Modal.js
@@ -39,7 +39,7 @@ function Modal(props) {
           'modal',
           'w-full',
           'h-full',
-          'sm:w-auto',
+          // 'sm:w-auto',
           'sm:h-auto',
           'max-w-lg',
           'relative',


### PR DESCRIPTION
This PR fixes 75% of https://app.clubhouse.io/yeep/story/55/role-permission-org-modals-enhancements as follows:

**`<PermissionEditModal />` as well as `<RoleEditModal />` now have the organization scope "locked" to prevent editing:**

![image](https://user-images.githubusercontent.com/14941382/69897101-a46a5e80-134f-11ea-95eb-3b256d410791.png)

**A `fullWidth` parameter has been specified to allow forms shown inside a modal to be "greedy" and take as much width as they need**
Why not have a `max-width` prop? The challenge here is the responsive nature of the `<Modal />`. Since Yeep is mobile-first (or tries to be), the default width class is `w-full` (100% width). This allows for a simple mobile UX experience with the modal (it basically behaves like a "page"):
![image](https://user-images.githubusercontent.com/14941382/69897131-f317f880-134f-11ea-881e-d092cf404adc.png)

On desktop sizes however, we specify a max-width using `max-w-lg` and then need to apply `sm:w-auto` which will tell the `<Modal />` to size itself based on it's contents.

The flexbox layout of the forms (label on left, field on right) interferes slightly with this and can result in edit forms that appear quite squashed. Passing in the `fullWidth` prop to the `<Modal />` will ensure that the `sm:w-auto` class is _not_ added, this allowing the nested form to "spread itself" to the full width.
